### PR TITLE
Fix "Swift runtime failure: arithmetic overflow" when running on SPI-Server repo

### DIFF
--- a/Breadcrumbs/Model/FileSource.swift
+++ b/Breadcrumbs/Model/FileSource.swift
@@ -24,7 +24,7 @@ class FileSource {
 
     func lines(max: UInt) -> [Line] {
         var result = [Line]()
-        for number in (location.line-1)...(location.line+max) where number < contents.count {
+        for number in (location.line > 0 ? location.line-1 : 0)...(location.line+max) where number < contents.count {
             result.append(
                 Line(number: number, text: contents[Int(number)].appending("\n"))
             )


### PR DESCRIPTION
I have no idea if this fix makes sense but the app was crashing when running it on https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server where `location.line` ends up being 0.

The repo can be opened with this change and links seem to be working fine, so maybe this a good fix? Not sure 😄