### PR TITLE
Allow multiple prefixes for a category

### DIFF
--- a/Breadcrumbs/Model/CrumbCategory.swift
+++ b/Breadcrumbs/Model/CrumbCategory.swift
@@ -14,7 +14,7 @@ struct CrumbCategory: Identifiable, Hashable {
     var id: String { name }
 
     let name: String
-    let prefix: String
+    let prefixes: [String]
     let icon: String
     let tint: Color
     var children: [Crumb]? = nil


### PR DESCRIPTION
Change CrumbCategory.prefix -> prefixes and make it a String array. Add an extra loop to iterate over all the different possible prefixes.

Also fixes a bug where categories weren't skipped when a prefix was found